### PR TITLE
Prevent structures from spawning everywhere

### DIFF
--- a/so_lime.json
+++ b/so_lime.json
@@ -60,6 +60,71 @@
             "spacing": 32,
             "separation": 8,
             "salt": 10387312
+          },
+          "minecraft:desert_pyramid": {
+            "spacing": 32,
+            "separation": 8,
+            "salt": 14357617
+          },
+          "minecraft:igloo": {
+            "spacing": 32,
+            "separation": 8,
+            "salt": 14357618
+          },
+          "minecraft:jungle_pyramid": {
+            "spacing": 32,
+            "separation": 8,
+            "salt": 14357619
+          },
+          "minecraft:swamp_hut": {
+            "spacing": 32,
+            "separation": 8,
+            "salt": 14357620
+          },
+          "minecraft:pillager_outpost": {
+            "spacing": 32,
+            "separation": 8,
+            "salt": 165745296
+          },
+          "minecraft:stronghold": {
+            "spacing": 1,
+            "separation": 0,
+            "salt": 0
+          },
+          "minecraft:monument": {
+            "spacing": 32,
+            "separation": 5,
+            "salt": 10387313
+          },
+          "minecraft:mansion": {
+            "spacing": 80,
+            "separation": 20,
+            "salt": 10387319
+          },
+          "minecraft:buried_treasure": {
+            "spacing": 1,
+            "separation": 0,
+            "salt": 0
+          },
+          "minecraft:mineshaft": {
+            "spacing": 1,
+            "separation": 0,
+            "salt": 0
+          },
+          "minecraft:ruined_portal": {
+            "spacing": 40,
+            "separation": 15,
+            "salt": 34222645
+          },
+          "minecraft:shipwreck": {
+            "spacing": 24,
+            "separation": 4,
+            "salt": 165745295
+          },
+          "minecraft:ocean_ruin": {
+            "spacing": 20,
+            "separation": 8,
+            "salt": 14357621
           }
         }
       }


### PR DESCRIPTION
Due to [MC-185019](https://bugs.mojang.com/browse/MC-185019), you need to put all structure defaults. 

The default values were taken from [AmberWat/RealFakeDimensionsData](https://github.com/AmberWat/RealFakeDimensionsData)

Before:
<img width="480" alt="javaw_rdhFWMjYrh" src="https://user-images.githubusercontent.com/17352009/86668704-324bad80-bff3-11ea-89e7-d3607026b170.png">
After:
<img width="480" alt="javaw_vmxHQECNiV" src="https://user-images.githubusercontent.com/17352009/86668737-38da2500-bff3-11ea-8b5b-b66ccebd08b4.png">
